### PR TITLE
Uninitialized constant when used with Rails 3

### DIFF
--- a/lib/exception_notifier.rb
+++ b/lib/exception_notifier.rb
@@ -4,21 +4,21 @@ require 'exception_notifier/notifier'
 class ExceptionNotifier
   def self.default_ignore_exceptions
     [].tap do |exceptions|
-      exceptions << ActiveRecord::RecordNotFound if defined? ActiveRecord
-      exceptions << AbstractController::ActionNotFound if defined? AbstractController
-      exceptions << ActionController::RoutingError if defined? ActionController
+      exceptions << ::ActiveRecord::RecordNotFound if defined?(::ActiveRecord::RecordNotFound)
+      exceptions << ::AbstractController::ActionNotFound if defined?(::AbstractController::ActionNotFound)
+      exceptions << ::ActionController::RoutingError if defined?(::ActionController::RoutingError)
     end
   end
 
   def initialize(app, options = {})
     @app, @options = app, options
-    @options[:ignore_exceptions] ||= self.class.default_ignore_exceptions
   end
 
   def call(env)
     @app.call(env)
   rescue Exception => exception
     options = (env['exception_notifier.options'] ||= {})
+    @options[:ignore_exceptions] ||= self.class.default_ignore_exceptions
     options.reverse_merge!(@options)
 
     unless Array.wrap(options[:ignore_exceptions]).include?(exception.class)


### PR DESCRIPTION
Hey, 
as described in ticket no. 87 (see https://rails.lighthouseapp.com/projects/8995-rails-plugins/tickets/87), when using exception_notification middleware with Rails, you get an "Uninitialized constant" exception. Lawrence Pit provided the patch, which I just put as a pull request.
