### PR TITLE
Condition to use ExceptionNotifier only in production

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ As of Rails 3 ExceptionNotifier is used as a rack middleware
   Whatever::Application.config.middleware.use ExceptionNotifier,
     :email_prefix => "[Whatever] ",
     :sender_address => %{"notifier" <notifier@example.com>},
-    :exception_recipients => %w{exceptions@example.com}
+    :exception_recipients => %w{exceptions@example.com} if Rails.env.production?
 
 == Customization
 


### PR DESCRIPTION
Hi,

I've added the condition to use ExceptionNotifier only when running in production to the README -- as using it in other environments does not make much sense (by default),

best!,

Karel
