### PR TITLE
no longer notify about 404 or InvalidAuthenticityToken errors

### DIFF
--- a/lib/exception_notification/notifiable.rb
+++ b/lib/exception_notification/notifiable.rb
@@ -50,7 +50,7 @@ private
   end
   
   def deliver_exception_notification?
-    !self.class.skip_exception_notifications? && ![404, "404 Not Found"].include?(response.status)
+    !self.class.skip_exception_notifications? && !["404", "422", "404 Not Found"].include?(response.status.to_s)
   end
   
   def notify_about_exception(exception)


### PR DESCRIPTION
Looks like something in Rails changed, as response.status is now a string and not an int. I made sure the incude?() comparison works and also stopped notifying about 422-based errors.
